### PR TITLE
Fallback for text gradient for non-Webkit browsers

### DIFF
--- a/frontend/src/styles/partials/_mixins.scss
+++ b/frontend/src/styles/partials/_mixins.scss
@@ -78,7 +78,7 @@
 @mixin text-gradient($color1, $color2) {
   color: $color1;
   -webkit-text-fill-color: transparent;
-  background: linear-gradient(45deg, $color1, $color1 30%, $color2 70%, $color2);
+  background-image: -webkit-linear-gradient(45deg, $color1, $color1 30%, $color2 70%, $color2);
   -webkit-background-clip: text;
 }
 


### PR DESCRIPTION
In newer non-Webkit browsers (Edge, Firefox 50+) and in all Webkit based browsers this results in a gradient, while in older non-Webkit browsers (IE, Firefox 50-) this results in a solid color, the first color, provided as a fallback.

Previous behavior caused a gradient background even in non-Webkit browsers, resulting in usability issues. This has been fixed by using -webkit- prefix so gradient is only applied in the supported browsers.