### PR TITLE
GCI Task: Added styling for sample images

### DIFF
--- a/frontend/src/styles/demo.scss
+++ b/frontend/src/styles/demo.scss
@@ -5,9 +5,22 @@
 @import 'partials/animations';
 @import 'partials/typography';
 @import 'partials/theme';
+@import 'partials/tabs';
 
 body {
   overflow: auto !important;
+}
+
+.ant-row{
+  display: inline-block;
+  width: 100% !important;
+  img{
+    float: left;
+    margin: 1em;
+    height: 20em;
+    width: 30% !important;
+    border-radius: 10%;
+  }
 }
 
 .origami-demo-wrapper {
@@ -117,7 +130,7 @@ body {
           width: 100%;
         }
 
-@media only screen and (max-width: 600px) {
+@media #{$bp-mobile} {
   .origami-demo-heading {
     width: 100%;
   }

--- a/frontend/src/styles/demo.scss
+++ b/frontend/src/styles/demo.scss
@@ -12,14 +12,22 @@ body {
 }
 
 .ant-row{
-  display: inline-block;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: center;
   width: 100% !important;
-  img{
-    float: left;
-    margin: 1em;
-    height: 20em;
-    width: 30% !important;
-    border-radius: 10%;
+  div{
+    width: 100%;
+  }
+  .ant-col-5{
+    max-width: 23%;
+    margin: 1%;
+    img{
+      height: 100%;
+      width: 100% !important;
+      border-radius: 5%;
+    }
   }
 }
 


### PR DESCRIPTION
Right now it contains dummy styles but it can be changed as wanted.
This style is only applied to the sample images due to the unique html structure.

![Before](https://user-images.githubusercontent.com/22736920/34271525-9819261e-e6b2-11e7-8028-9c2850fba43f.png)
![After](https://user-images.githubusercontent.com/22736920/34271528-9931c2a4-e6b2-11e7-956d-63b64e85013b.png)
