### PR TITLE
Modify demo link to support all demos

### DIFF
--- a/frontend/src/components/home/homeBody/HomeDemos.js
+++ b/frontend/src/components/home/homeBody/HomeDemos.js
@@ -106,7 +106,7 @@ class HomeDemos extends React.Component {
             <Link to={demo.source_code_url} target="_blank">
               <Button extraClass="cv-home-demos-source">Source code</Button>
             </Link>
-            <Link to={`/projects/${demo.permalink}`} target="_blank">
+            <Link to={demo.permalink} target="_blank">
               <Button themeClass="cv-button-dark" extraClass="cv-button-small">
                 Demo
               </Button>


### PR DESCRIPTION
@deshraj @uttu357 Please review the PR.

I have modified the `Demo` link on the home page in order to work with all the demos we are having since all the demos aren't hosted on CloudCV. So, now all the demos will open in a new tab rather than opening in a iframe under Projects sections of cloudcv website. 