### PR TITLE
Remove projects page

### DIFF
--- a/frontend/src/components/navbar/index.js
+++ b/frontend/src/components/navbar/index.js
@@ -53,7 +53,7 @@ class Navbar extends Component {
     let projectActive = firstPath === "projects";
     let listItems = [
       "",
-      "Projects",
+      // "Projects",
       "GSoC",
       "Team",
       "Contribute",


### PR DESCRIPTION
This PR is a fix for not showing the demos on the projects page in an iframe. For now, we are removing the projects page and it will be back once we resolve the iframe issues with the other demos.