### PR TITLE
Fix #112 : Update HomeNews.js for a spelling error of January as Januray.

### DIFF
--- a/frontend/src/components/home/homeBody/HomeNews.js
+++ b/frontend/src/components/home/homeBody/HomeNews.js
@@ -154,7 +154,7 @@ const EVENTS = [
     )
   },
   {
-    date: "Januray 2014",
+    date: "January 2014",
     desc: <span>NVIDIA supports CloudCV with a GPU hardware donation</span>
   },
   {


### PR DESCRIPTION
Updated Timeline for Spelling Error of January as Januray.