### PR TITLE
Add GSOC 2020 year to team section

### DIFF
--- a/frontend/src/components/team/TeamSection.js
+++ b/frontend/src/components/team/TeamSection.js
@@ -10,7 +10,7 @@ const TeamSection = props => {
       <h3 className="cv-home-showcase-heading">{props.title}</h3>
     );
   const MEMBERS = props.members;
-  const YEARS = [2019, 2018, 2017, 2016, 2015];
+  const YEARS = [2020, 2019, 2018, 2017, 2016, 2015];
   const memberElements =
     props.title === "GSoC Students, Mentors and Interns" ? (
       YEARS.map((year, index) => {


### PR DESCRIPTION
### Description

Add year 2020 on team page. For DB entries to be shown on the page we have to manually make an entry on the teams page.