### PR TITLE
Update rsa package version

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,5 +1,6 @@
 -r base.txt
 
+rsa==3.1.4
 gunicorn==19.7.1
 raven==6.1.0
 boto==2.47.0


### PR DESCRIPTION
### Description

Fixing `rsa` version to `3.1.14` to fix python 2 dependency issue