### PR TITLE
Changed Django-suit version from 0.2.25 to 0.2.26

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,4 +4,4 @@ Pillow==4.1.1
 python-memcached==1.58
 djangorestframework==3.9.1
 django-cors-headers==2.1.0
-django-suit==0.2.25
+django-suit==0.2.26


### PR DESCRIPTION
Most of the working enviornments support django-suit version 0.2.26 . It also helped me when i was setting up my working enviornment !

IMPORTANT NOTES (please read, then delete):

* The PR title should start with "Fix #bugnum: " (if applicable), followed by a clear one-line present-tense summary of the changes introduced in the PR. For example: "Fix #bugnum: Introduce the first version of the collection editor.".

* Please make sure to mention "#bugnum" somewhere in the description of the PR. This enables GitHub to link the PR to the corresponding bug.